### PR TITLE
Show progress bar for the ReST conversion process

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5,10 +5,6 @@ from epub2sphinx import constants
 import os
 import shutil
 
-def get_file_name(individual_file):
-    if individual_file is not None:
-        return individual_file.name
-
 @click.command()
 @click.option('-o','--output-directory',type=click.Path(),help=constants.cli_option_output_directory_help)
 @click.option('-t','--theme','sphinx_theme_name',default="alabaster",type=str,prompt=True,help=constants.cli_option_theme_help)
@@ -34,11 +30,8 @@ def convert(output_directory,sphinx_theme_name,input_file,post_conversion,includ
             click.echo("Aborting")
             exit(1)
 
-    input_files= [input_file]
-    with click.progressbar(input_files,label="converting to sphinx",item_show_func=get_file_name) as bar:
-        for individual_file in bar:
-            c = epub2sphinx.Converter(individual_file.name,output_directory,sphinx_theme_name.lower(),include_custom_css)
-            c.convert()
+    c = epub2sphinx.Converter(input_file.name,output_directory,sphinx_theme_name.lower(),include_custom_css)
+    c.convert()
 
     if post_conversion:
         # Build using Sphinx


### PR DESCRIPTION
Previously the progress bar was shown for the total conversion of individual
input files which will be (currently) only one and hence it was not
looking good and it did not show where it's actually taking the time.

Fix for issue #19 

### Old progress bar UI
https://user-images.githubusercontent.com/24192122/142731231-a5e70359-3d93-47b1-b213-285fd7d6bca8.mov

### New progress bar UI
https://user-images.githubusercontent.com/24192122/142731240-588dc93c-6393-4e98-8830-65f89d0f1c1f.mov