### PR TITLE
Build HTML files by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ build/
 develop-eggs/
 dist/
 downloads/
+tmp/
 eggs/
 .eggs/
 lib/

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Built during [FOSSHack 21](https://fossunited.org/fosshack/2021) to solve [this 
 
 ## Usage
 ```
-Usage: epub2sphinx <epub_file_name> [-o <output_directory_path>] [-t <sphinx_theme_name>] [-b,--build|-B,--no-build] [-s|--server] [-c]
+Usage: epub2sphinx <epub_file_name> [-o <output_directory_path>] [-t <sphinx_theme_name>] [-b,--build|-B,--no-build] [-s|--serve] [-c] [-p <port_number>]
 
   This tool helps you to convert your epub files into sphinx format for a better reading experience.
   Kindly provide the epub file as the argument to this command.

--- a/README.md
+++ b/README.md
@@ -25,25 +25,25 @@ Built during [FOSSHack 21](https://fossunited.org/fosshack/2021) to solve [this 
 
 ## Usage
 ```
-Usage: epub2sphinx <epub_file_name> [-o <output_directory_path>] [-t <sphinx_theme_name>] [-s|--server|-b|--build] [-c]
+Usage: epub2sphinx <epub_file_name> [-o <output_directory_path>] [-t <sphinx_theme_name>] [-b,--build|-B,--no-build] [-s|--server] [-c]
 
   This tool helps you to convert your epub files into sphinx format for a better reading experience.
   Kindly provide the epub file as the argument to this command.
 
 Options:
-  -o, --output-directory PATH  The name of the output directory where the ReST file will be generated.
-                               Kindly make sure that the given directory is not existing already.
-  -t, --theme TEXT             The name of the sphinx theme.You can check for the available themes at:
-                               <https://www.sphinx-doc.org/en/master/usage/theming.html#builtin-themes>
-  -b, --build                  Build HTML from the generated ReST files using Sphinx.
-                               Sphinx has to be installed for this to work.
-  -s, --serve                  Build HTML using Sphinx and Serve the files on localhost.
-                               Sphinx has to be installed for this to work.
-  -c, --include-custom-css     Include the custom CSS and Fonts from the EPUB for the HTML output
-  -p, --port INTEGER           The port number on which the files will be served after conversion
-  --overwrite                  Overwrite the output directory if present already
-  --version                    Show the version and exit.
-  --help                       Show this message and exit.
+  -o, --output-directory PATH   The name of the output directory where the ReST file will be generated.
+                                Kindly make sure that the given directory is not existing already.
+  -t, --theme TEXT              The name of the sphinx theme.You can check for the available themes at:
+                                <https://www.sphinx-doc.org/en/master/usage/theming.html#builtin-themes>
+  -b, --build / -B, --no-build  Build HTML from the generated ReST files using Sphinx.
+                                Sphinx has to be installed for this to work.  [default: b]
+  -s, --serve                   Build HTML using Sphinx and Serve the files on localhost.
+                                Sphinx has to be installed for this to work.
+  -c, --include-custom-css      Include the custom CSS and Fonts from the EPUB for the HTML output
+  --overwrite                   Overwrite the output directory if present already
+  -p, --port INTEGER            The port number on which the files will be served after conversion
+  --version                     Show the version and exit.
+  --help                        Show this message and exit.
 ```
 ### Example
 ```

--- a/cli.py
+++ b/cli.py
@@ -65,14 +65,16 @@ def convert(output_directory, sphinx_theme_name, input_file, build, serve, inclu
 
 def check_port_availability(host: str, port: int):
     """
-    Check if the port provided by the user is available to serve
+    Check if the port provided by the user is available to serve.
+
     :param host: 127.0.0.1
     :param port: 8000
     :return: Bool
     """
     with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
-        return False if sock.connect_ex((host, port)) == 0 else True
-            
+        return sock.connect_ex((host, port)) != 0
+
+
 def default_output_directory(file_name: str) -> str:
     """
     Generate the default output directory path from the given file name in the current working directory.

--- a/cli.py
+++ b/cli.py
@@ -15,12 +15,12 @@ from epub2sphinx import constants
               help=constants.cli_option_theme_help)
 @click.argument('input_file', type=click.File("r"))
 @click.option('-b/-B', '--build/--no-build', 'build', is_flag=True, default=True, help=constants.cli_option_build_help, show_default=True)
-@click.option('-s', '--serve', 'post_conversion', flag_value='serve', help=constants.cli_option_serve_help)
+@click.option('-s', '--serve', 'serve', is_flag=True, help=constants.cli_option_serve_help)
 @click.option('-c', '--include-custom-css', is_flag=True, help=constants.cli_option_css_help)
 @click.option('--overwrite', is_flag=True, help=constants.cli_option_overwrite_help)
 @click.option('-p', '--port', type=int, default=0, help=constants.cli_option_port_help)
 @click.version_option(package_name='epub2sphinx')
-def convert(output_directory, sphinx_theme_name, input_file, build, post_conversion, include_custom_css, overwrite, port):
+def convert(output_directory, sphinx_theme_name, input_file, build, serve, include_custom_css, overwrite, port):
     '''\b
         This tool helps you to convert your epub files into sphinx format for a better reading experience.
         Kindly provide the epub file as the argument to this command.
@@ -55,7 +55,7 @@ def convert(output_directory, sphinx_theme_name, input_file, build, post_convers
         build_exit_code = subprocess.call(["make html"], shell=True, stdout=subprocess.PIPE)
         html_path = os.path.join('build', 'html')
         if build_exit_code == 0 and os.path.isdir(html_path):
-            if post_conversion == 'serve':
+            if serve:
                 # Serve on localhost
                 os.chdir(html_path)
                 # 0 will automatically make use of the next available port

--- a/cli.py
+++ b/cli.py
@@ -14,13 +14,13 @@ from epub2sphinx import constants
 @click.option('-t', '--theme', 'sphinx_theme_name', default="alabaster", type=str, prompt=True,
               help=constants.cli_option_theme_help)
 @click.argument('input_file', type=click.File("r"))
-@click.option('-b', '--build', 'post_conversion', flag_value='build', help=constants.cli_option_build_help)
+@click.option('-b/-B', '--build/--no-build', 'build', is_flag=True, default=True, help=constants.cli_option_build_help, show_default=True)
 @click.option('-s', '--serve', 'post_conversion', flag_value='serve', help=constants.cli_option_serve_help)
 @click.option('-c', '--include-custom-css', is_flag=True, help=constants.cli_option_css_help)
 @click.option('--overwrite', is_flag=True, help=constants.cli_option_overwrite_help)
 @click.option('-p', '--port', type=int, default=0, help=constants.cli_option_port_help)
 @click.version_option(package_name='epub2sphinx')
-def convert(output_directory, sphinx_theme_name, input_file, post_conversion, include_custom_css, overwrite, port):
+def convert(output_directory, sphinx_theme_name, input_file, build, post_conversion, include_custom_css, overwrite, port):
     '''\b
         This tool helps you to convert your epub files into sphinx format for a better reading experience.
         Kindly provide the epub file as the argument to this command.
@@ -49,7 +49,7 @@ def convert(output_directory, sphinx_theme_name, input_file, post_conversion, in
     c.convert()
     click.echo("Conversion finished in {:.2f}s".format(time.time() - start_time))
 
-    if post_conversion:
+    if build:
         # Build using Sphinx
         os.chdir(output_directory)
         build_exit_code = subprocess.call(["make html"], shell=True, stdout=subprocess.PIPE)

--- a/cli.py
+++ b/cli.py
@@ -31,12 +31,9 @@ def convert(output_directory, sphinx_theme_name, input_file, build, serve, inclu
             click.echo(f"Port {port} is already in use. Aborting!")
             exit(1)
 
-    if not output_directory:
-        output_name = input_file.name.split(os.path.sep)[-1]
-        if output_name.endswith(".epub"):
-            output_name = output_name[:-5]
-        output_directory = os.path.join(os.getcwd(), output_name)
-        click.echo("Writing output to {}".format(output_directory))
+    output_directory = output_directory or default_output_directory(input_file.name)
+    click.echo("Writing output to {}".format(output_directory))
+
     if os.path.isdir(output_directory):
         if overwrite or click.confirm("{} already exists, Do you want to overwrite it?".format(output_directory)):
             shutil.rmtree(output_directory)
@@ -76,3 +73,14 @@ def check_port_availability(host: str, port: int):
     with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
         return False if sock.connect_ex((host, port)) == 0 else True
             
+def default_output_directory(file_name: str) -> str:
+    """
+    Generate the default output directory path from the given file name in the current working directory.
+
+    :param str file_name: The name of the input (EPUB) file
+    :return: the path where the ReST/HTML files should be placed
+    :rtype: str
+    """
+    output_name = file_name.split(os.path.sep)[-1]
+    output_name = output_name.removesuffix('.epub')
+    return os.path.join(os.getcwd(), output_name)


### PR DESCRIPTION
Right now to generate HTML files from an epub file, we will do something like below
```sh
epub2sphinx -o sample -t classic   sample.epub                               # (Step 1)
cd sample                                                                    # (Step 2)
make html                                                                    # (Step 3)
```

With this change, (Step 1) will be enough to generate the HTML files. The HTML files will be generated even if the `-b` flag is not specified.

If `-B` flag is specified, the execution will stop without any post conversions.

In addition to this,
- included a change to ignore `.tmp` folder in the project
- refactored two methods in `cli.py` and `convert.py`
- minor style changes